### PR TITLE
Upcoming breaking changes in `loo_compare()` output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 -*- text -*-
 
+Version 1.1.1 (development)
+-------------------------
+
+* Updated compatibility with upcoming changes to `loo_compare()` output
+  structure in the `loo` package (> 2.9.0), which now returns a data frame
+  instead of a matrix and includes additional diagnostic columns.
+
+
 Version 1.1.0 (2023-09-09)
 -------------------------
 

--- a/tests/slow/test_loo.R
+++ b/tests/slow/test_loo.R
@@ -21,7 +21,9 @@ test_that("loo, MCMC", {
   loo2 <- loo(db2)
   lc <- loo::loo_compare(loo1,loo2)
   if ("model" %in% colnames(lc)) {
-    lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+    expect_true(
+      lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+    )
   } else {
     expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
   }
@@ -60,7 +62,9 @@ test_that("loo, hierarchical",{
   loo2 <- loo(db2)
   lc <- loo::loo_compare(loo1,loo2)
   if ("model" %in% colnames(lc)) {
-    lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+    expect_true(
+      lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+    )
   } else {
     expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
   }

--- a/tests/slow/test_loo.R
+++ b/tests/slow/test_loo.R
@@ -20,7 +20,11 @@ test_that("loo, MCMC", {
   loo1 <- loo(db1)
   loo2 <- loo(db2)
   lc <- loo::loo_compare(loo1,loo2)
-  expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
+  if ("model" %in% colnames(lc)) {
+    lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+  } else {
+    expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
+  }
   
   ## Individual contributions  
   li <- loo_indiv(loo1)
@@ -55,7 +59,11 @@ test_that("loo, hierarchical",{
   loo1 <- loo(db1)
   loo2 <- loo(db2)
   lc <- loo::loo_compare(loo1,loo2)
-  expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
+  if ("model" %in% colnames(lc)) {
+    lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+  } else {
+    expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
+  }
   
   li <- loo_indiv(loo1)
   expect_equal(table(li$var)[[1]], 1700)

--- a/tests/testthat/test_loo.R
+++ b/tests/testthat/test_loo.R
@@ -22,7 +22,9 @@ test_that("loo, standard ", {
   suppressWarnings(loo2 <- loo(db2))
   lc <- loo::loo_compare(loo1,loo2)
   if ("model" %in% colnames(lc)) {
-    lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+    expect_true(
+      lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+    )
   } else {
     expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
   }

--- a/tests/testthat/test_loo.R
+++ b/tests/testthat/test_loo.R
@@ -21,7 +21,11 @@ test_that("loo, standard ", {
   suppressWarnings(loo1 <- loo(db1))
   suppressWarnings(loo2 <- loo(db2))
   lc <- loo::loo_compare(loo1,loo2)
-  expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
+  if ("model" %in% colnames(lc)) {
+    lc[lc$model == "model1", "elpd_diff"] > lc[lc$model == "model2", "elpd_diff"]
+  } else {
+    expect_true(lc["model1","elpd_diff"] > lc["model2","elpd_diff"])
+  }
   
   ## Individual contributions  
   li <- loo_indiv(loo1)


### PR DESCRIPTION
## Description
In the `loo` package, we are making changes to the output structure returned by `loo_compare()` in [PR #300](https://github.com/stan-dev/loo/pull/300). The main changes are a transition from a matrix to a data frame and the addition of several new columns. Here is an example of the updated output structure:

```
> loo_compare(w1, w2)
  model elpd_diff se_diff p_worse diag_diff diag_elpd
 model1       0.0     0.0      NA                    
 model2      -4.1     0.1    1.00   N < 100     
     
Diagnostic flags present.
See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
or https://mc-stan.org/loo/reference/loo-glossary.html.
```

More context on the motivation behind these changes can be found in the updated case study ["Uncertainty in Bayesian LOO-CV Model Comparison"](https://users.aalto.fi/~ave/casestudies/LOO_uncertainty/loo_uncertainty.html).

A **reverse dependency check revealed that these changes will affect your package**. To help smooth the transition, I have already reviewed your code and suggest within this PR changes that should keep your package compatible with both the current and the upcoming `loo_compare()` output structure.

I may have missed some additional spots in your code that need updating, so please feel free to point those out and I am happy to help. Thank you and please do not hesitate to reach out if you have any questions or concerns.